### PR TITLE
Expanded settings to include colors

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -2,12 +2,19 @@
 let options = {
     twitterImages: true,
     twitterGifs: true,
+    colorNoAlt: '#FF0000',
+    colorAltBg: '#0000FF',
+    colorAltText: '#FFFFFF',
 };
 
 // Get the users preferences
 chrome.storage.sync.get(["options"], function (result) {
     if (result.options) {
-        options = result.options;
+        options.twitterImages = result.options.twitterImages || options.twitterImages;
+        options.twitterGifs = result.options.twitterGifs || options.twitterGifs;
+        options.colorNoAlt = result.options.colorNoAlt || options.colorNoAlt;
+        options.colorAltBg = result.options.colorAltBg || options.colorAltBg;
+        options.colorAltText = result.options.colorAltText || options.colorAltText;
     }
 });
 
@@ -44,11 +51,11 @@ let insertAlt = function () {
                 !userGif.getAttribute("aria-label") ||
                 userGif.getAttribute("aria-label") == "Embedded video"
             ) {
-                altText.style.backgroundColor = "red";
+                altText.style.backgroundColor = options.colorNoAlt;
                 altText.style.height = "12px";
             } else {
-                altText.style.color = "white";
-                altText.style.backgroundColor = "blue";
+                altText.style.color = options.colorAltText;
+                altText.style.backgroundColor = options.colorAltBg;
                 altText.style.fontSize = "18px";
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
@@ -88,11 +95,11 @@ let insertAlt = function () {
                 !userImage.getAttribute("alt") ||
                 userImage.getAttribute("alt") == "Image"
             ) {
-                altText.style.backgroundColor = "red";
+                altText.style.backgroundColor = options.colorNoAlt;
                 altText.style.height = "12px";
             } else {
-                altText.style.color = "white";
-                altText.style.backgroundColor = "blue";
+                altText.style.color = options.colorAltText;
+                altText.style.backgroundColor = options.colorAltBg;
                 altText.style.fontSize = "18px";
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =

--- a/options.html
+++ b/options.html
@@ -21,6 +21,27 @@
             </label>
         </p>
 
+        <p>
+            <label>
+                <input type="color" value="#FF0000" id="color_no_alt">
+                No alt text color
+            </label>
+        </p>
+
+        <p>
+            <label>
+                <input type="color" value="#0000FF" id="color_alt_background">
+                Alt text background color
+            </label>
+        </p>
+
+        <p>
+            <label>
+                <input type="color" value="#FFFFFF" id="color_alt_text">
+                Alt text color
+            </label>
+        </p>
+
         <div id="status"></div>
         <button id="save">Save</button>
 

--- a/options.js
+++ b/options.js
@@ -1,8 +1,20 @@
+// If sync.get fails, we default to everything on
+let default_options = {
+    twitterImages: true,
+    twitterGifs: true,
+    colorNoAlt: '#FF0000',
+    colorAltBg: '#0000FF',
+    colorAltText: '#FFFFFF',
+};
+
 // Saves options to chrome.storage
 function save_options() {
     let options = {
         twitterImages: document.getElementById("twitter_images").checked,
         twitterGifs: document.getElementById("twitter_gifs").checked,
+        colorNoAlt: document.getElementById("color_no_alt").value,
+        colorAltBg: document.getElementById("color_alt_background").value,
+        colorAltText: document.getElementById("color_alt_text").value,
     };
 
     chrome.storage.sync.set(
@@ -25,17 +37,20 @@ function restore_options() {
     // Use default values
     chrome.storage.sync.get(
         {
-            options: {
-                twitterImages: true,
-                twitterGifs: true,
-            },
+            options: default_options
         },
         function (items) {
             document.getElementById("twitter_images").checked =
-                items.options.twitterImages;
+                items.options.twitterImages || default_options.twitterImages;
             document.getElementById("twitter_gifs").checked =
-                items.options.twitterGifs;
-        }
+                items.options.twitterGifs || default_options.twitterGifs;
+            document.getElementById("color_no_alt").value =
+                items.options.colorNoAlt || default_options.colorNoAlt;
+            document.getElementById("color_alt_background").value =
+                items.options.colorAltBg || default_options.colorAltBg;
+            document.getElementById("color_alt_text").value =
+                items.options.colorAltText || default_options.colorAltText;
+            }
     );
 }
 document.addEventListener("DOMContentLoaded", restore_options);


### PR DESCRIPTION
Updated settings storage to be an object and allow the customization of colors.

This should also resolve the issue of first install options not being set.

## Result

![Screen Shot 2021-06-16 at 5 45 56 AM](https://user-images.githubusercontent.com/37359/122198587-4a64b780-ce67-11eb-8cb0-5f79fc3ffc28.png)

Closes #4 
