### PR TITLE
Initial LinkedIn support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ View the extension options to turn the different platforms and media types on an
 - [x] Facebook (experimental, single image posts working)
 - [x] Instagram (experimental, single image posts working)
 - [x] Tweetdeck (experimental, single image posts working)
-- [ ] LinkedIn
+- [x] LinkedIn (experimental)
 
 ## To test
 

--- a/contentScript.js
+++ b/contentScript.js
@@ -5,6 +5,7 @@ let options = {
     instagramImages: true,
     facebookImages: true,
     tweetdeckImages: true,
+    linkedinImages: true,
     colorNoAlt: "#FF0000",
     colorAltBg: "#0000FF",
     aiColorAltBg: "#750238",
@@ -30,6 +31,10 @@ chrome.storage.sync.get(["options"], function (result) {
         )
             ? result.options.tweetdeckImages
             : options.tweetdeckImages;
+
+        options.linkedinImages = result.options.hasOwnProperty("linkedinImages")
+            ? result.options.linkedinImages
+            : options.linkedinImages;
 
         options.colorNoAlt = result.options.colorNoAlt || options.colorNoAlt;
         options.colorAltBg = result.options.colorAltBg || options.colorAltBg;
@@ -76,6 +81,62 @@ let insertAlt = function () {
               "div.js-tweet a.js-media-image-link, div.js-modal-panel img.media-img"
           )
         : [];
+
+    // LinkedIn images
+    const linkedinImages = options.linkedinImages
+        ? document.querySelectorAll(
+              "div.feed-shared-image img.feed-shared-image__image"
+          )
+        : [];
+
+    linkedinImages.forEach(function (lnImage) {
+        if (lnImage.getAttribute("data-altdisplayed") !== "true") {
+            let imageLink =
+                lnImage.parentElement.parentElement.parentElement.parentElement
+                    .parentElement;
+
+            // Container for visible text
+            const altText = document.createElement("div");
+            altText.setAttribute("aria-hidden", "true");
+            altText.style.borderBottomRightRadius = "14px";
+            altText.style.borderBottomLeftRadius = "14px";
+
+            // Move around the border radius
+            lnImage.style.borderBottomRightRadius = "0px";
+            lnImage.style.borderBottomLeftRadius = "0px";
+
+            if (
+                !lnImage.getAttribute("alt") ||
+                lnImage.getAttribute("alt") ==
+                    "No alternative text description for this image"
+            ) {
+                altText.style.backgroundColor = options.colorNoAlt;
+                altText.style.height = "12px";
+            } else if (lnImage.getAttribute("alt").includes("Image preview")) {
+                altText.style.color = options.colorAltText;
+                altText.style.backgroundColor = options.aiColorAltBg;
+                altText.style.fontSize = "18px";
+                altText.style.padding = "4px 8px";
+                altText.style.fontFamily =
+                    'Arial, "Helvetica Neue", Helvetica, sans-serif';
+                altText.textContent = lnImage.getAttribute("alt");
+            } else {
+                altText.style.color = options.colorAltText;
+                altText.style.backgroundColor = options.colorAltBg;
+                altText.style.fontSize = "14px";
+                altText.style.padding = "4px 8px";
+                altText.style.fontFamily =
+                    'Arial, "Helvetica Neue", Helvetica, sans-serif';
+                altText.textContent = lnImage.getAttribute("alt");
+            }
+
+            if (imageLink) {
+                imageLink.append(altText);
+            }
+
+            lnImage.setAttribute("data-altdisplayed", "true");
+        }
+    });
 
     tweetdeckImages.forEach(function (tdImage) {
         if (tdImage.getAttribute("data-altdisplayed") !== "true") {

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
         "https://twitter.com/*",
         "https://tweetdeck.twitter.com/*",
         "https://www.instagram.com/*",
-        "https://www.facebook.com/*"
+        "https://www.facebook.com/*",
+        "https://www.linkedin.com/*"
       ],
       "js": ["contentScript.js"],
       "run_at": "document_end"
@@ -23,7 +24,8 @@
   "host_permissions": [
     "https://*.twitter.com/",
     "https://www.instagram.com/",
-    "https://www.facebook.com/"
+    "https://www.facebook.com/",
+    "https://www.linkedin.com/"
   ],
   "icons": {
     "16": "/images/visual-alt-16.png",

--- a/options.html
+++ b/options.html
@@ -26,21 +26,28 @@
             <p>
                 <label>
                     <input type="checkbox" id="instagram_images" />
-                    Instagram images (experimental)
+                    Instagram images
                 </label>
             </p>
 
             <p>
                 <label>
                     <input type="checkbox" id="facebook_images" />
-                    Facebook images (experimental)
+                    Facebook images
                 </label>
             </p>
 
             <p>
                 <label>
                     <input type="checkbox" id="tweetdeck_images" />
-                    Tweetdeck images (experimental)
+                    Tweetdeck images
+                </label>
+            </p>
+
+            <p>
+                <label>
+                    <input type="checkbox" id="linkedin_images" />
+                    LinkedIn images
                 </label>
             </p>
         </fieldset>

--- a/options.js
+++ b/options.js
@@ -5,6 +5,7 @@ let default_options = {
     instagramImages: true,
     facebookImages: true,
     tweetdeckImages: true,
+    linkedinImages: true,
     colorNoAlt: "#FF0000",
     colorAltBg: "#0000FF",
     aiColorAltBg: "#750238",
@@ -19,6 +20,7 @@ function save_options() {
         instagramImages: document.getElementById("instagram_images").checked,
         facebookImages: document.getElementById("facebook_images").checked,
         tweetdeckImages: document.getElementById("tweetdeck_images").checked,
+        linkedinImages: document.getElementById("linkedin_images").checked,
         colorNoAlt: document.getElementById("color_no_alt").value,
         colorAltBg: document.getElementById("color_alt_background").value,
         aiColorAltBg: document.getElementById("ai_color_alt_background").value,
@@ -72,6 +74,11 @@ function restore_options() {
                 items.options.hasOwnProperty("tweetdeckImages")
                     ? items.options.tweetdeckImages
                     : default_options.tweetdeckImages;
+
+            document.getElementById("linkedin_images").checked =
+                items.options.hasOwnProperty("linkedinImages")
+                    ? items.options.linkedinImages
+                    : default_options.linkedinImages;
 
             document.getElementById("color_no_alt").value =
                 items.options.colorNoAlt || default_options.colorNoAlt;


### PR DESCRIPTION
Initial LinkedIn support for images with detection if the image text is machine-generated (when detectable). 

The following situations are now available:

## Single images

| With alt | Without alt |
|--------|--------|
| ![Single screenshot of post with green box under and alt text visible](https://user-images.githubusercontent.com/37359/139579778-cc889e9c-54a0-458a-ade0-aa574b5f9f63.png) | ![Single screenshot of post with red box under image](https://user-images.githubusercontent.com/37359/139579789-340a1fcc-9cb0-4e19-9e00-47bbe1b2d4cc.png) |
 
## Machine-generated alt

![Single screenshot of post with alternate color bar under photo](https://user-images.githubusercontent.com/37359/139579838-57c69283-3d01-4bed-888b-0c31660b1b30.png)

## Multiple images

| With alt | Without alt |
|--------|--------|
| ![Single screenshot of post with multiple images and red color bar under photo](https://user-images.githubusercontent.com/37359/139579891-dc61e44c-15e4-4fa1-a877-ca8b9301058f.png) | ![Single screenshot of post with multiple images and alternate color bar under photo](https://user-images.githubusercontent.com/37359/139579871-981fd613-c7b9-45ae-a0a6-b8ec5cfde165.png) |

Closes #10 