### PR TITLE
Fixes #15 - Twitter GIFs no longer continiously expand

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -275,11 +275,11 @@ let insertAlt = function () {
 
     timelineGifs.forEach(function (userGif) {
         if (userGif.getAttribute("data-altdisplayed") !== "true") {
-            // Twitter June 2021 visible container
+            // Twitter August 2022 visible container
             let gifLink =
                 userGif.parentElement.parentElement.parentElement.parentElement
                     .parentElement.parentElement.parentElement.parentElement
-                    .parentElement.parentElement;
+                    .parentElement.parentElement.parentElement;
 
             // Container for visible text
             const altText = document.createElement("div");

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Social visual alt text",
   "description": "Visually show alternative text of social media images",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "manifest_version": 3,
   "options_ui": {
     "page": "options.html",


### PR DESCRIPTION
With the introduction of additional HTML elements in the Twitter DOM the placement of the injected alt text was causing an issue with an elements expanding vertically forever.

Fixes #15 

## Result

<img width="634" alt="Screen Shot 2022-08-20 at 7 46 30 AM" src="https://user-images.githubusercontent.com/37359/185744676-627d1708-32b8-4220-92e4-80d38614cad0.png">

