### PR TITLE
Fixes #17 - Instagram profile images no longer displaying alt text

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -64,7 +64,7 @@ let insertAlt = function () {
     // Instagram images
     const instagramImages = options.instagramImages
         ? document.querySelectorAll(
-              'main article img[src^="https://scontent"]:not([data-testid="user-avatar"]), main article img[src^="https://instagram"]:not([data-testid="user-avatar"])'
+              'main article img[src^="https://scontent"]:not([alt*="profile picture"]), main article img[src^="https://instagram"]:not([alt*="profile picture"])'
           )
         : [];
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Social visual alt text",
   "description": "Visually show alternative text of social media images",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "manifest_version": 3,
   "options_ui": {
     "page": "options.html",


### PR DESCRIPTION
Fixes #17 - Instagram profile images no longer displaying alt text

## Result

<img width="429" alt="Screen Shot 2022-08-21 at 7 40 36 AM" src="https://user-images.githubusercontent.com/37359/185789351-7300b8e3-cd3e-4877-8b78-1aef80ad218a.png">

