### PR TITLE
Mastodon now only runs when the #mastodon DOM element is detected on a page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Social visual alt text",
   "description": "Visually show alternative text of social media images",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "manifest_version": 3,
   "options_ui": {
     "page": "options.html",

--- a/src/mastodon.js
+++ b/src/mastodon.js
@@ -45,9 +45,12 @@ let mastodonLoop = function mastodonLoop() {
 };
 
 async function initMastodon() {
-    const result = await getOptions();
-    if (result.mastodonImages !== false) {
-        mastodonLoop();
+    // Only continue and pull options if this is a Mastodon site (could be at any URL)
+    if (document.getElementById('mastodon') !== null) {
+        const result = await getOptions();
+        if (result.mastodonImages !== false) {
+            mastodonLoop();
+        }
     }
 }
 


### PR DESCRIPTION
Since Mastodon script runs on every page load, this helps optimize the get options sync to only pull and start on pages that contain the `#mastodon` element.