### PR TITLE
Rework mastodon logic to correct order (again), tweak look

### DIFF
--- a/src/mastodon.js
+++ b/src/mastodon.js
@@ -1,48 +1,54 @@
-// Search for items with alt text
+// Search for all media gallery containers
 let insertMDAlt = function () {
-    const mastodonImages = options.mastodonImages
-        ? document.querySelectorAll("#mastodon .media-gallery__item img")
+
+    const mastodonMediaGalleries = options.mastodonImages
+        ? document.querySelectorAll("#mastodon .media-gallery")
         : [];
 
-    let visualAlt = document.createElement("div");
-    visualAlt.setAttribute("aria-hidden", "true");
-    let imageContainer = null;
+    // Iterate over all media galleries
+    mastodonMediaGalleries.forEach(function (mDMediaGallery) {
 
-    mastodonImages.forEach(function (mDImage) {
-        if (mDImage.getAttribute("data-altdisplayed") !== "true") {
-            imageContainer = mDImage.parentElement.parentElement.parentElement;
+        if (mDMediaGallery.getAttribute("data-altdisplayed") !== "true") {
 
-            // Container for visible text
-            let altText = document.createElement("div");
-            altText.style.borderBottomRightRadius = "14px";
-            altText.style.borderBottomLeftRadius = "14px";
+            let visualAlt = document.createElement("div");
+            visualAlt.setAttribute("aria-hidden", "true");
+            
+            let mastodonImages = mDMediaGallery.querySelectorAll('.media-gallery__item img');
 
-            if (
-                !mDImage.getAttribute("alt") ||
-                mDImage.getAttribute("alt") == ""
-            ) {
-                altText.style.backgroundColor = options.colorNoAlt;
-                altText.style.height = "12px";
-            } else {
-                altText.style.color = options.colorAltText;
-                altText.style.backgroundColor = options.colorAltBg;
-                altText.style.fontSize = "14px";
-                altText.style.padding = "4px 8px";
-                altText.style.fontFamily =
-                    'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.textContent = mDImage.getAttribute("alt");
-            }
+            // Iterate over all images in that media gallery
+            mastodonImages.forEach(function (mDImage) {
 
-            if (imageContainer) {
-                visualAlt.appendChild(altText);
-            }
+                if (mDImage.getAttribute("data-altdisplayed") !== "true") {
 
-            mDImage.setAttribute("data-altdisplayed", "true");
+                    // Container for visible text
+                    let altText = document.createElement("div");
+                    altText.style.borderBottomRightRadius = "14px";
+                    altText.style.borderBottomLeftRadius = "14px";
 
-            if (imageContainer) {
-                imageContainer.after(visualAlt);
-                visualAlt = document.createElement("div");
-            }
+                    if (
+                        !mDImage.getAttribute("alt") ||
+                        mDImage.getAttribute("alt") == ""
+                    ) {
+                        altText.style.backgroundColor = options.colorNoAlt;
+                        altText.style.height = "12px";
+                    } else {
+                        altText.style.color = options.colorAltText;
+                        altText.style.backgroundColor = options.colorAltBg;
+                        altText.style.fontSize = "14px";
+                        altText.style.padding = "4px 8px";
+                        altText.style.fontFamily =
+                            'Arial, "Helvetica Neue", Helvetica, sans-serif';
+                        altText.textContent = mDImage.getAttribute("alt");
+                    }
+
+                    visualAlt.appendChild(altText);
+                    mDImage.setAttribute("data-altdisplayed", "true");
+                }
+            });
+
+            // Add container with all alts to this particular media gallery
+            mDMediaGallery.after(visualAlt);
+            mDMediaGallery.setAttribute("data-altdisplayed", "true");
         }
     });
 };

--- a/src/mastodon.js
+++ b/src/mastodon.js
@@ -22,8 +22,8 @@ let insertMDAlt = function () {
 
                     // Container for visible text
                     let altText = document.createElement("div");
-                    altText.style.borderBottomRightRadius = "14px";
-                    altText.style.borderBottomLeftRadius = "14px";
+                    altText.style.borderRadius = "4px";
+                    altText.style.marginTop = "1px";
 
                     if (
                         !mDImage.getAttribute("alt") ||
@@ -37,7 +37,7 @@ let insertMDAlt = function () {
                         altText.style.fontSize = "14px";
                         altText.style.padding = "4px 8px";
                         altText.style.fontFamily =
-                            'Arial, "Helvetica Neue", Helvetica, sans-serif';
+                            "Arial, 'Helvetica Neue', Helvetica, sans-serif";
                         altText.textContent = mDImage.getAttribute("alt");
                     }
 


### PR DESCRIPTION
Fixes the issue of the out-of-order alt texts https://github.com/nickdenardis/social-visual-alt-text/issues/23 that was originally fixed, but resurfaced https://github.com/nickdenardis/social-visual-alt-text/issues/23#issuecomment-1628812040

* replace the single big loop for all images with a cleaner, more explicit nested loop (loop over media galleries, and for each media gallery loop over its images).

Using https://sfba.social/@foxprimephotos/110689589131925729 as an example:

Before:

![Screenshot of a mastodon post with two images, and the alt text underneath them in reverse order](https://github.com/nickdenardis/social-visual-alt-text/assets/895831/92df19c2-f549-4333-a894-7f3744f4ca3a)


After:

![The same mastodon post, now showing the alt in the correct order](https://github.com/nickdenardis/social-visual-alt-text/assets/895831/8ddf51f0-a454-416d-8c84-9ad0c9dc96cc)
