### PR TITLE
Tweak mastodon appearance

### DIFF
--- a/src/mastodon.js
+++ b/src/mastodon.js
@@ -22,9 +22,11 @@ let insertMDAlt = function () {
 
                     // Container for visible text
                     let altText = document.createElement("div");
+                    altText.className = "status__content";
+                    altText.style.fontSize = "0.9rem";
                     altText.style.borderRadius = "4px";
                     altText.style.marginTop = "1px";
-
+                    altText.style.boxSizing = "border-box";
                     if (
                         !mDImage.getAttribute("alt") ||
                         mDImage.getAttribute("alt") == ""
@@ -34,10 +36,7 @@ let insertMDAlt = function () {
                     } else {
                         altText.style.color = options.colorAltText;
                         altText.style.backgroundColor = options.colorAltBg;
-                        altText.style.fontSize = "14px";
-                        altText.style.padding = "4px 8px";
-                        altText.style.fontFamily =
-                            "Arial, 'Helvetica Neue', Helvetica, sans-serif";
+                        altText.style.padding = "0.75rem 1rem";
                         altText.textContent = mDImage.getAttribute("alt");
                     }
 


### PR DESCRIPTION
* add `status__content` class (to inherit most basic styles like font and line height, and to correctly adapt to images in a thread)
* remove some of the explicit styles (as they're now inherited)

Before:

Images in a thread have the alt container overlap the left-hand "thread" line
![screenshot of an image in a thread](https://github.com/nickdenardis/social-visual-alt-text/assets/895831/e385917b-0e42-492d-9e0c-d053d491877b)

After:

Alt container now adapts to the width in a thread correctly. also note the subtle tweak in font size and line height
![screenshot of an image in a thread, with the alt container now adapting to the width of the message in the thread](https://github.com/nickdenardis/social-visual-alt-text/assets/895831/71762e81-b7c6-45e3-86f7-e9901e8ac201)

---

Before:

Font size/line height before, in a regular toot/post
![screenshot of an image with multiline alt text](https://github.com/nickdenardis/social-visual-alt-text/assets/895831/d2e87240-34f5-4821-93fc-bf0808c5cb93)

After:

Font size/line height closer to the regular text of a post
![screenshot of an image with multiline alt text](https://github.com/nickdenardis/social-visual-alt-text/assets/895831/d167611e-ba71-4dc2-a374-a336d4651855)

