### PR TITLE
Instagram individual page alt text now visible on single and multiple images

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Social visual alt text",
   "description": "Visually show alternative text of social media images",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "manifest_version": 3,
   "options_ui": {
     "page": "options.html",

--- a/src/instagram.js
+++ b/src/instagram.js
@@ -3,7 +3,7 @@ let insertIGAlt = function () {
     // Instagram images
     const instagramImages = options.instagramImages
         ? document.querySelectorAll(
-              'main article img[src^="https://scontent"]:not([draggable="false"], [alt*="highlight story picture"]), div[role="button"] img[src^="https://scontent"]:not([draggable="false"], [alt*="highlight story picture"]), main article img[src^="https://instagram"]:not([alt*="profile picture"])'
+              'main article img[src^="https://scontent"]:not([draggable="false"], [alt*="highlight story picture"]), div[role="button"] img[src^="https://scontent"]:not([draggable="false"], [alt*="highlight story picture"])'
           )
         : [];
 
@@ -15,23 +15,36 @@ let insertIGAlt = function () {
             // Container for visible text
             const altText = document.createElement("div");
             altText.setAttribute("aria-hidden", "true");
-            // altText.style.maxWidth = "600px";
 
-            let hasMultipleImages = false;
-            let mainSection = document.querySelector('section main')
-            if (mainSection !== null) {
-                hasMultipleImages = mainSection.querySelector('ul') !== null;
-                imageLink = document.querySelector('section main').firstElementChild.firstElementChild;
+            const onViewPage = window.location.href.includes("/p/");
+            const inOverlay = igImage.closest("article");
+
+            // Deteremine where to put the alt text in the DOM
+            if (!onViewPage) {
+                imageLink = igImage.closest('div[role="button"]');
+            } else if (inOverlay) {
+                imageLink = igImage.closest('div[role="button"]');
+                imageLink =
+                    imageLink.parentElement.parentElement.parentElement
+                        .parentElement.parentElement.parentElement.parentElement
+                        .parentElement;
+            } else {
+                // If on individual item view
+                let hasMultipleImages = false;
+                let mainSection = document.querySelector("section main");
+                if (mainSection !== null) {
+                    hasMultipleImages =
+                        mainSection.querySelector("ul") !== null;
+                    imageLink =
+                        document.querySelector("section main").firstElementChild
+                            .firstElementChild;
+                }
             }
-            
 
             if (
                 !igImage.getAttribute("alt") ||
                 igImage.getAttribute("alt") == "Image"
             ) {
-                imageLink =
-                    igImage.parentElement.parentElement.parentElement
-                        .parentElement.parentElement;
                 altText.style.backgroundColor = options.colorNoAlt;
                 altText.style.height = "12px";
             } else if (
@@ -71,16 +84,8 @@ let instagramLoop = function instagramLoop() {
 
 async function initInstagram() {
     const result = await getOptions();
-    
     if (result.instagramImages !== false) {
-        // If on an individual instagram page
-        const url = window.location.href;
-        const onViewPage = url.includes('/p/') && url.split('/').length > 2;
-        const onReelPage = url.includes('/reel/') && url.split('/').length > 2;
-
-        if (!onReelPage) {
-            (onViewPage)?insertIGAlt():instagramLoop();
-        }
+        instagramLoop();
     }
 }
 

--- a/src/instagram.js
+++ b/src/instagram.js
@@ -3,7 +3,7 @@ let insertIGAlt = function () {
     // Instagram images
     const instagramImages = options.instagramImages
         ? document.querySelectorAll(
-              'main article img[src^="https://scontent"]:not([alt*="profile picture"]), main article img[src^="https://instagram"]:not([alt*="profile picture"])'
+              'main article img[src^="https://scontent"]:not([draggable="false"], [alt*="highlight story picture"]), div[role="button"] img[src^="https://scontent"]:not([draggable="false"], [alt*="highlight story picture"]), main article img[src^="https://instagram"]:not([alt*="profile picture"])'
           )
         : [];
 
@@ -15,7 +15,15 @@ let insertIGAlt = function () {
             // Container for visible text
             const altText = document.createElement("div");
             altText.setAttribute("aria-hidden", "true");
-            altText.style.maxWidth = "600px";
+            // altText.style.maxWidth = "600px";
+
+            let hasMultipleImages = false;
+            let mainSection = document.querySelector('section main')
+            if (mainSection !== null) {
+                hasMultipleImages = mainSection.querySelector('ul') !== null;
+                imageLink = document.querySelector('section main').firstElementChild.firstElementChild;
+            }
+            
 
             if (
                 !igImage.getAttribute("alt") ||
@@ -63,8 +71,16 @@ let instagramLoop = function instagramLoop() {
 
 async function initInstagram() {
     const result = await getOptions();
+    
     if (result.instagramImages !== false) {
-        instagramLoop();
+        // If on an individual instagram page
+        const url = window.location.href;
+        const onViewPage = url.includes('/p/') && url.split('/').length > 2;
+        const onReelPage = url.includes('/reel/') && url.split('/').length > 2;
+
+        if (!onReelPage) {
+            (onViewPage)?insertIGAlt():instagramLoop();
+        }
     }
 }
 


### PR DESCRIPTION
Fixes Instagram DOM changes and allows for multiple images to show alt text while scrolling through them.

## Individual view fixed

| Before | After |
|--------|--------|
| <img width="854" alt="Screenshot 2024-09-28 at 6 24 10 PM" src="https://github.com/user-attachments/assets/0b5edb44-350c-4c0d-ba36-f53b2df836da"> | <img width="981" alt="Screenshot 2024-09-28 at 6 56 06 PM" src="https://github.com/user-attachments/assets/00478e4d-5d84-4313-8f14-011c469cba49"> |

## Multiple images fixed

| Before | After |
|--------|--------|
| <img width="526" alt="Screenshot 2024-09-28 at 6 18 51 PM" src="https://github.com/user-attachments/assets/f438a1ff-f5df-4b6f-91dc-000007565b1a"> | ![captions-multiple](https://github.com/user-attachments/assets/48dd8a75-6f25-4af5-855c-2e17cf018973) |

Fixes #3 #31 #32 