### PR TITLE
Alt text for images and GIFs on Bluesky now visually displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ View the extension options to turn the different platforms and media types on an
 
 - [x] Twitter images
 - [x] Twitter GIFs
-- [x] Facebook (experimental, single image posts working)
-- [x] Instagram (experimental, single image posts working)
-- [x] Tweetdeck (experimental, single image posts working)
-- [x] LinkedIn (experimental)
+- [x] Facebook
+- [x] Instagram
+- [x] Tweetdeck
+- [x] LinkedIn 
+- [x] Mastadon 
+- [x] Bluesky
 
 ## Twitter examples
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Social visual alt text",
   "description": "Visually show alternative text of social media images",
-  "version": "0.7.17",
+  "version": "0.8.0",
   "manifest_version": 3,
   "options_ui": {
     "page": "options.html",
@@ -36,6 +36,11 @@
     {
       "matches": ["https://www.facebook.com/*"],
       "js": ["src/facebook.js"],
+      "run_at": "document_end"
+    },
+    {
+      "matches": ["https://bsky.app/*"],
+      "js": ["src/bluesky.js"],
       "run_at": "document_end"
     }
   ],

--- a/options.html
+++ b/options.html
@@ -54,7 +54,14 @@
             <p>
                 <label>
                     <input type="checkbox" id="mastodon_images" />
-                    Mastodon images (experimental)
+                    Mastodon images
+                </label>
+            </p>
+
+            <p>
+                <label>
+                    <input type="checkbox" id="bluesky_images" />
+                    Blueksy images
                 </label>
             </p>
         </fieldset>

--- a/options.js
+++ b/options.js
@@ -7,6 +7,7 @@ let default_options = {
     tweetdeckImages: true,
     linkedinImages: true,
     mastodonImages: true,
+    blueskyImages: true,
     colorNoAlt: "#FF0000",
     colorAltBg: "#0000FF",
     aiColorAltBg: "#750238",
@@ -23,6 +24,7 @@ function save_options() {
         tweetdeckImages: document.getElementById("tweetdeck_images").checked,
         linkedinImages: document.getElementById("linkedin_images").checked,
         mastodonImages: document.getElementById("mastodon_images").checked,
+        blueskyImages: document.getElementById("bluesky_images").checked,
         colorNoAlt: document.getElementById("color_no_alt").value,
         colorAltBg: document.getElementById("color_alt_background").value,
         aiColorAltBg: document.getElementById("ai_color_alt_background").value,
@@ -86,6 +88,11 @@ function restore_options() {
                 items.options.hasOwnProperty("mastodonImages")
                     ? items.options.mastodonImages
                     : default_options.mastodonImages;
+            
+            document.getElementById("bluesky_images").checked =
+                items.options.hasOwnProperty("blueskyImages")
+                    ? items.options.blueskyImages
+                    : default_options.blueskyImages;
 
             document.getElementById("color_no_alt").value =
                 items.options.colorNoAlt || default_options.colorNoAlt;

--- a/src/bluesky.js
+++ b/src/bluesky.js
@@ -1,0 +1,112 @@
+let insertAlt = function () {
+    // Images (single or multiple)
+    const timelineImages = options.blueskyImages
+        ? document.querySelectorAll(
+              'main div[data-testid="contentHider-post"] img[src^="https://cdn.bsky.app/img/feed_thumbnail/"]'
+          )
+        : [];
+
+    // GIFs
+    const timelineGIFs = options.blueskyImages
+        ? document.querySelectorAll(
+              'main div[data-testid="contentHider-post"] video[src^="https://t.gifs.bsky.app/"]'
+          )
+        : [];
+
+    timelineImages.forEach(function (userImage) {
+        if (userImage.getAttribute("data-altdisplayed") !== "true") {
+            // Where to put the alt text in the DOM
+            let imageLink =
+                userImage.parentElement.parentElement.parentElement
+                    .parentElement.parentElement.parentElement.parentElement
+                    .parentElement;
+
+            // Check to see if this image is to a link (no need to show alt text)
+            let closestLink = userImage.closest("a");
+            const isExternal =
+                closestLink && closestLink.getAttribute("target") == "_blank";
+
+            // Container for visible text
+            const altText = document.createElement("div");
+            altText.setAttribute("aria-hidden", "true");
+
+            // Determine if the image has alt text on it
+            if (
+                !userImage.getAttribute("alt") ||
+                userImage.getAttribute("alt") == "Image"
+            ) {
+                altText.style.backgroundColor = options.colorNoAlt;
+                altText.style.height = "12px";
+            } else {
+                altText.style.color = options.colorAltText;
+                altText.style.backgroundColor = options.colorAltBg;
+                altText.style.fontSize = "18px";
+                altText.style.padding = "4px 8px";
+                altText.style.fontFamily =
+                    'Arial, "Helvetica Neue", Helvetica, sans-serif';
+                altText.textContent = userImage.getAttribute("alt");
+            }
+
+            // Add the element to the DOM
+            if (imageLink && !isExternal) {
+                imageLink.append(altText);
+            }
+
+            // Keep track of the images with alt displayed
+            userImage.setAttribute("data-altdisplayed", "true");
+        }
+    });
+
+    timelineGIFs.forEach(function (userImage) {
+        if (userImage.getAttribute("data-altdisplayed") !== "true") {
+            // Where to put the alt text in the DOM
+            let imageLink =
+                userImage.parentElement.parentElement.parentElement
+                    .parentElement.parentElement.parentElement;
+
+            // Container for visible text
+            const altText = document.createElement("div");
+            altText.setAttribute("aria-hidden", "true");
+
+            // Determine if the image has alt text on it
+            if (
+                !userImage.getAttribute("aria-label") ||
+                userImage.getAttribute("aria-label") == "Image"
+            ) {
+                altText.style.backgroundColor = options.colorNoAlt;
+                altText.style.height = "12px";
+            } else {
+                altText.style.color = options.colorAltText;
+                altText.style.backgroundColor = options.colorAltBg;
+                altText.style.fontSize = "18px";
+                altText.style.padding = "4px 8px";
+                altText.style.fontFamily =
+                    'Arial, "Helvetica Neue", Helvetica, sans-serif';
+                altText.textContent = userImage.getAttribute("aria-label");
+            }
+
+            // Add the element to the DOM
+            if (imageLink) {
+                imageLink.append(altText);
+            }
+
+            // Keep track of the images with alt displayed
+            userImage.setAttribute("data-altdisplayed", "true");
+        }
+    });
+};
+
+let blueskyLoop = function blueskyLoop() {
+    insertAlt();
+    setTimeout(blueskyLoop, 500);
+};
+
+async function initBlueSky() {
+    const result = await getOptions();
+
+    if (result.blueskyImages !== false) {
+        blueskyLoop();
+    }
+}
+
+initBlueSky();

--- a/src/common.js
+++ b/src/common.js
@@ -7,6 +7,7 @@ let options = {
     tweetdeckImages: true,
     linkedinImages: true,
     mastodonImages: true,
+    blueskyImages: true,
     colorNoAlt: "#FF0000",
     colorAltBg: "#0000FF",
     aiColorAltBg: "#750238",
@@ -50,6 +51,12 @@ function getOptions() {
                 )
                     ? result.options.mastodonImages
                     : options.mastodonImages;
+
+                options.blueskyImages = result.options.hasOwnProperty(
+                    "blueskyImages"
+                )
+                    ? result.options.blueskyImages
+                    : options.blueskyImages;
 
                 options.colorNoAlt =
                     result.options.colorNoAlt || options.colorNoAlt;


### PR DESCRIPTION
The addition of Bsky alt text for images and GIFs now in place.

Works on the listing page and individual view pages.

| Single image with| Single image without |
|--------|--------|
| <img width="624" alt="Screenshot 2024-12-07 at 6 19 33 PM" src="https://github.com/user-attachments/assets/5d08d99e-4e53-4b68-b969-cfa7ed4a7e78"> | <img width="619" alt="Screenshot 2024-12-07 at 6 21 24 PM" src="https://github.com/user-attachments/assets/f84a3c2e-bd3d-4970-9ffb-bccd9fb17088"> |

| Multiple images | GIF |
|--------|--------|
| <img width="635" alt="Screenshot 2024-12-07 at 7 04 07 PM" src="https://github.com/user-attachments/assets/4de53ad4-5041-49e0-bc35-02db374d286a"> | <img width="616" alt="Screenshot 2024-12-07 at 7 16 34 PM" src="https://github.com/user-attachments/assets/44090b20-bb29-402c-9a66-daeda21961f0"> |