### PR TITLE
Support for images on Threads.net now available

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ View the extension options to turn the different platforms and media types on an
 - [x] LinkedIn 
 - [x] Mastadon 
 - [x] Bluesky
+- [x] Threads
 
 ## Twitter examples
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Social visual alt text",
   "description": "Visually show alternative text of social media images",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "manifest_version": 3,
   "options_ui": {
     "page": "options.html",
@@ -41,6 +41,11 @@
     {
       "matches": ["https://bsky.app/*"],
       "js": ["src/bluesky.js"],
+      "run_at": "document_end"
+    },
+    {
+      "matches": ["https://www.threads.net/*"],
+      "js": ["src/threads.js"],
       "run_at": "document_end"
     }
   ],

--- a/options.html
+++ b/options.html
@@ -64,6 +64,13 @@
                     Blueksy images
                 </label>
             </p>
+
+            <p>
+                <label>
+                    <input type="checkbox" id="threads_images" />
+                    Threads images
+                </label>
+            </p>
         </fieldset>
         <fieldset>
             <legend>Color options</legend>

--- a/options.js
+++ b/options.js
@@ -8,6 +8,7 @@ let default_options = {
     linkedinImages: true,
     mastodonImages: true,
     blueskyImages: true,
+    threadsImages: true,
     colorNoAlt: "#FF0000",
     colorAltBg: "#0000FF",
     aiColorAltBg: "#750238",
@@ -25,6 +26,7 @@ function save_options() {
         linkedinImages: document.getElementById("linkedin_images").checked,
         mastodonImages: document.getElementById("mastodon_images").checked,
         blueskyImages: document.getElementById("bluesky_images").checked,
+        threadsImages: document.getElementById("threads_images").checked,
         colorNoAlt: document.getElementById("color_no_alt").value,
         colorAltBg: document.getElementById("color_alt_background").value,
         aiColorAltBg: document.getElementById("ai_color_alt_background").value,
@@ -93,6 +95,11 @@ function restore_options() {
                 items.options.hasOwnProperty("blueskyImages")
                     ? items.options.blueskyImages
                     : default_options.blueskyImages;
+            
+            document.getElementById("threads_images").checked =
+                items.options.hasOwnProperty("threadsImages")
+                    ? items.options.threadsImages
+                    : default_options.threadsImages;
 
             document.getElementById("color_no_alt").value =
                 items.options.colorNoAlt || default_options.colorNoAlt;

--- a/src/common.js
+++ b/src/common.js
@@ -8,6 +8,7 @@ let options = {
     linkedinImages: true,
     mastodonImages: true,
     blueskyImages: true,
+    threadsImages: true,
     colorNoAlt: "#FF0000",
     colorAltBg: "#0000FF",
     aiColorAltBg: "#750238",
@@ -57,6 +58,12 @@ function getOptions() {
                 )
                     ? result.options.blueskyImages
                     : options.blueskyImages;
+
+                options.threadsImages = result.options.hasOwnProperty(
+                    "threadsImages"
+                )
+                    ? result.options.threadsImages
+                    : options.threadsImages;
 
                 options.colorNoAlt =
                     result.options.colorNoAlt || options.colorNoAlt;

--- a/src/threads.js
+++ b/src/threads.js
@@ -1,0 +1,82 @@
+let insertAlt = function () {
+    // Images (single or multiple)
+    const timelineImages = options.threadsImages
+        ? document.querySelectorAll('div[aria-label="Column body"] picture img')
+        : [];
+
+    timelineImages.forEach(function (userImage) {
+        if (userImage.getAttribute("data-altdisplayed") !== "true") {
+            // Where to put the alt text in the DOM
+            let imageLink =
+                userImage.parentElement.parentElement.parentElement
+                    .parentElement.parentElement;
+
+            // Check to see if this image is to a link (no need to show alt text)
+            let closestLink = userImage.closest("a");
+            const isExternal =
+                closestLink && closestLink.getAttribute("target") == "_blank";
+
+            // Is there multiple images?
+            let img_container =
+                imageLink.parentElement.querySelectorAll("picture");
+            if (img_container && img_container.length > 1) {
+                imageLink = imageLink.parentElement.parentElement;
+            }
+
+            // Container for visible text
+            const altText = document.createElement("div");
+            altText.setAttribute("aria-hidden", "true");
+
+            // Determine if the image has alt text on it
+            if (
+                !userImage.getAttribute("alt") ||
+                userImage.getAttribute("alt") == "Image"
+            ) {
+                altText.style.backgroundColor = options.colorNoAlt;
+                altText.style.height = "12px";
+            } else if (
+                userImage.getAttribute("alt").includes("May be an image of") ||
+                userImage.getAttribute("alt").includes("Photo by")
+            ) {
+                altText.style.color = options.colorAltText;
+                altText.style.backgroundColor = options.aiColorAltBg;
+                altText.style.fontSize = "18px";
+                altText.style.padding = "4px 8px";
+                altText.style.fontFamily =
+                    'Arial, "Helvetica Neue", Helvetica, sans-serif';
+                altText.textContent = userImage.getAttribute("alt");
+            } else {
+                altText.style.color = options.colorAltText;
+                altText.style.backgroundColor = options.colorAltBg;
+                altText.style.fontSize = "18px";
+                altText.style.padding = "4px 8px";
+                altText.style.fontFamily =
+                    'Arial, "Helvetica Neue", Helvetica, sans-serif';
+                altText.textContent = userImage.getAttribute("alt");
+            }
+
+            // Add the element to the DOM
+            if (imageLink && !isExternal) {
+                imageLink.append(altText);
+            }
+
+            // Keep track of the images with alt displayed
+            userImage.setAttribute("data-altdisplayed", "true");
+        }
+    });
+};
+
+let threadsLoop = function threadsLoop() {
+    insertAlt();
+    setTimeout(threadsLoop, 500);
+};
+
+async function initThreads() {
+    const result = await getOptions();
+
+    if (result.threadsImages !== false) {
+        threadsLoop();
+    }
+}
+
+initThreads();


### PR DESCRIPTION
Support for Threads.net incoming.

| Single | Multiple | With defined alt text |
|--------|--------|--------|
| <img width="668" alt="Screenshot 2024-12-25 at 10 49 38 AM" src="https://github.com/user-attachments/assets/8179d0be-c617-4d1d-9c21-52e6acec297b" /> | <img width="674" alt="Screenshot 2024-12-25 at 10 46 42 AM" src="https://github.com/user-attachments/assets/c4ebb271-dd9f-4193-8a05-abe1ae763ff3" /> | <img width="688" alt="Screenshot 2024-12-25 at 11 00 31 AM" src="https://github.com/user-attachments/assets/947f2558-605a-4678-a1a7-b1d6984d02c7" /> |

