### PR TITLE
User avatars on inbox now excluded from alt text view

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Social visual alt text",
   "description": "Visually show alternative text of social media images",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "manifest_version": 3,
   "options_ui": {
     "page": "options.html",

--- a/src/instagram.js
+++ b/src/instagram.js
@@ -3,7 +3,7 @@ let insertIGAlt = function () {
     // Instagram images
     const instagramImages = options.instagramImages
         ? document.querySelectorAll(
-              'main article img[src^="https://scontent"]:not([draggable="false"], [alt*="highlight story picture"]), div[role="button"] img[src^="https://scontent"]:not([draggable="false"], [alt*="highlight story picture"])'
+              'main article img[src^="https://scontent"]:not([draggable="false"], [alt*="highlight story picture"]), div[role="button"] img[src^="https://scontent"]:not([draggable="false"], [alt*="highlight story picture"], [alt*="User avatar"])'
           )
         : [];
 


### PR DESCRIPTION
Excluding the messages area profile images.

| Before | After |
|--------|--------|
| <img width="451" alt="Screenshot 2024-12-31 at 8 54 06 AM" src="https://github.com/user-attachments/assets/3e452437-daa1-4805-bf74-75705db3de72" /> | <img width="387" alt="Screenshot 2024-12-31 at 9 04 28 AM" src="https://github.com/user-attachments/assets/6e5e46b3-77b6-451d-a239-da655c42d65f" /> |