### PR TITLE
Newlines in alt text now display visually

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Social visual alt text",
   "description": "Visually show alternative text of social media images",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "manifest_version": 3,
   "options_ui": {
     "page": "options.html",

--- a/src/bluesky.js
+++ b/src/bluesky.js
@@ -44,7 +44,7 @@ let insertAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.textContent = userImage.getAttribute("alt");
+                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("alt")));
             }
 
             // Add the element to the DOM
@@ -82,7 +82,7 @@ let insertAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.textContent = userImage.getAttribute("aria-label");
+                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("aria-label")));
             }
 
             // Add the element to the DOM

--- a/src/common.js
+++ b/src/common.js
@@ -79,3 +79,7 @@ function getOptions() {
         });
     });
 }
+
+function newlineToBr(text) {
+    return text.replace(/\n/g, "<br>");
+}

--- a/src/facebook.js
+++ b/src/facebook.js
@@ -45,7 +45,7 @@ let insertFBAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.textContent = fbImage.getAttribute("alt");
+                altText.insertAdjacentHTML('beforeend', newlineToBr(fbImage.getAttribute("alt")));
             } else {
                 altText.style.color = options.colorAltText;
                 altText.style.backgroundColor = options.colorAltBg;
@@ -53,7 +53,7 @@ let insertFBAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.textContent = fbImage.getAttribute("alt");
+                altText.insertAdjacentHTML('beforeend', newlineToBr(fbImage.getAttribute("alt")));
             }
 
             if (imageLink) {

--- a/src/linkedin.js
+++ b/src/linkedin.js
@@ -35,7 +35,7 @@ let insertLNAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.textContent = lnImage.getAttribute("alt");
+                altText.insertAdjacentHTML('beforeend', newlineToBr(lnImage.getAttribute("alt")));
             } else {
                 altText.style.color = options.colorAltText;
                 altText.style.backgroundColor = options.colorAltBg;
@@ -43,7 +43,7 @@ let insertLNAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.textContent = lnImage.getAttribute("alt");
+                altText.insertAdjacentHTML('beforeend', newlineToBr(lnImage.getAttribute("alt")));
             }
 
             if (imageLink) {

--- a/src/mastodon.js
+++ b/src/mastodon.js
@@ -36,6 +36,7 @@ let insertMDAlt = function () {
                         altText.style.backgroundColor = options.colorAltBg;
                         altText.style.padding = "0.75rem 1rem";
                         altText.textContent = alt;
+                        altText.insertAdjacentHTML('beforeend', newlineToBr(alt));
                     }
 
                     visualAlt.appendChild(altText);

--- a/src/threads.js
+++ b/src/threads.js
@@ -44,7 +44,7 @@ let insertAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.textContent = userImage.getAttribute("alt");
+                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("alt")));
             } else {
                 altText.style.color = options.colorAltText;
                 altText.style.backgroundColor = options.colorAltBg;
@@ -52,7 +52,7 @@ let insertAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.textContent = userImage.getAttribute("alt");
+                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("alt")));
             }
 
             // Add the element to the DOM

--- a/src/tweetdeck.js
+++ b/src/tweetdeck.js
@@ -47,9 +47,8 @@ let insertTDAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.textContent =
-                    tdImage.getAttribute("alt") ||
-                    tdImage.getAttribute("title");
+                let alt_text = tdImage.getAttribute("alt") || tdImage.getAttribute("title");
+                altText.insertAdjacentHTML('beforeend', newlineToBr(alt_text));
             }
 
             if (imageLink) {

--- a/src/twitter.js
+++ b/src/twitter.js
@@ -55,7 +55,7 @@ let insertTWAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.textContent = userImage.getAttribute("alt");
+                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("alt")));
             }
 
             if (imageLink) {
@@ -92,7 +92,7 @@ let insertTWAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.textContent = userGif.getAttribute("aria-label");
+                altText.insertAdjacentHTML('beforeend', newlineToBr(userGif.getAttribute("aria-label")));
             }
 
             if (gifLink) {


### PR DESCRIPTION
Fix to visually display newline characters in alt attributes. 

Closes #40 

| Before | After |
|--------|--------|
| <img width="628" alt="Screenshot 2025-02-21 at 7 22 36 AM" src="https://github.com/user-attachments/assets/4e6cb966-6520-4560-8490-6d5d11108433" /> | <img width="628" alt="Screenshot 2025-02-21 at 7 21 48 AM" src="https://github.com/user-attachments/assets/db9c164e-2d30-4bb1-aa98-3e334df676f8" /> |
