### PR TITLE
Add Bluesky Video Support

### DIFF
--- a/src/bluesky.js
+++ b/src/bluesky.js
@@ -108,10 +108,9 @@ let insertAlt = function () {
 
         if (anchorDiv.getAttribute("data-altdisplayed") !== "true") { 
             // Where to put the alt text in the DOM
-            let imageLink = userImage.closest('div[data-testid="contentHider-post"]')
-                ? anchorDiv.parentElement.parentElement.parentElement
-                    .parentElement.parentElement.parentElement
-                : anchorDiv.parentElement.parentElement;
+            let imageLink =
+                anchorDiv.parentElement.parentElement.parentElement
+                    .parentElement.parentElement;
 
             // Container for visible text
             const altText = document.createElement("div");

--- a/src/bluesky.js
+++ b/src/bluesky.js
@@ -13,6 +13,13 @@ let insertAlt = function () {
           )
         : [];
 
+    // Videos
+    const timelineVideos = options.blueskyImages
+        ? document.querySelectorAll(
+              'main div[aria-label="Embedded video player"] figure'
+          )
+        : [];
+
     timelineImages.forEach(function (userImage) {
         if (userImage.getAttribute("data-altdisplayed") !== "true") {
             // Where to put the alt text in the DOM
@@ -91,6 +98,42 @@ let insertAlt = function () {
             }
 
             // Keep track of the images with alt displayed
+            userImage.setAttribute("data-altdisplayed", "true");
+        }
+    });
+
+    timelineVideos.forEach(function (userImage) {
+        if (userImage.getAttribute("data-altdisplayed") !== "true") { 
+            // Where to put the alt text in the DOM
+            let imageLink =
+                userImage.parentElement.parentElement.parentElement
+                    .parentElement.parentElement.parentElement;
+
+            // Container for visible text
+            const altText = document.createElement("div");
+            altText.setAttribute("aria-hidden", "true");
+
+            // Determine if the video has alt text on it
+            const figcaption = userImage.querySelector('figcaption');
+            if (!figcaption) {
+                altText.style.backgroundColor = options.colorNoAlt;
+                altText.style.height = "12px";
+            } else {
+                altText.style.color = options.colorAltText;
+                altText.style.backgroundColor = options.colorAltBg;
+                altText.style.fontSize = "18px";
+                altText.style.padding = "4px 8px";
+                altText.style.fontFamily =
+                    'Arial, "Helvetica Neue", Helvetica, sans-serif';
+                altText.insertAdjacentHTML('beforeend', newlineToBr(figcaption.textContent));
+            }
+
+            // Add the element to the DOM
+            if (imageLink) {
+                imageLink.append(altText);
+            }
+
+            // Keep track of the videos with alt displayed
             userImage.setAttribute("data-altdisplayed", "true");
         }
     });

--- a/src/bluesky.js
+++ b/src/bluesky.js
@@ -105,8 +105,12 @@ let insertAlt = function () {
     timelineVideos.forEach(function (userImage) {
         if (userImage.getAttribute("data-altdisplayed") !== "true") { 
             // Where to put the alt text in the DOM
-            let imageLink =
-                userImage.parentElement.parentElement.parentElement
+            let imageLink = userImage.closest('div[data-testid="contentHider-post"]')
+                ? userImage.parentElement.parentElement.parentElement
+                    .parentElement.parentElement.parentElement
+                    .parentElement.parentElement.parentElement
+                    .parentElement.parentElement.parentElement
+                : userImage.parentElement.parentElement.parentElement
                     .parentElement.parentElement.parentElement;
 
             // Container for visible text

--- a/src/bluesky.js
+++ b/src/bluesky.js
@@ -103,15 +103,15 @@ let insertAlt = function () {
     });
 
     timelineVideos.forEach(function (userImage) {
-        if (userImage.getAttribute("data-altdisplayed") !== "true") { 
+        // DOM unrenders video element when scrolling away
+        const anchorDiv = userImage.parentElement.parentElement.parentElement
+
+        if (anchorDiv.getAttribute("data-altdisplayed") !== "true") { 
             // Where to put the alt text in the DOM
             let imageLink = userImage.closest('div[data-testid="contentHider-post"]')
-                ? userImage.parentElement.parentElement.parentElement
+                ? anchorDiv.parentElement.parentElement.parentElement
                     .parentElement.parentElement.parentElement
-                    .parentElement.parentElement.parentElement
-                    .parentElement.parentElement.parentElement
-                : userImage.parentElement.parentElement.parentElement
-                    .parentElement.parentElement.parentElement;
+                : anchorDiv.parentElement.parentElement;
 
             // Container for visible text
             const altText = document.createElement("div");
@@ -138,7 +138,7 @@ let insertAlt = function () {
             }
 
             // Keep track of the videos with alt displayed
-            userImage.setAttribute("data-altdisplayed", "true");
+            anchorDiv.setAttribute("data-altdisplayed", "true");
         }
     });
 };


### PR DESCRIPTION
Although it isn't normally visible in the bsky.app client, Bluesky videos can have alt text. This alt text exists in the DOM and can be displayed.

Examples:
| [With alt text](https://bsky.app/profile/did:plc:hx53snho72xoj7zqt5uice4u/post/3lkm6cflhr22x) | [Without alt text](https://bsky.app/profile/did:plc:355lbopbpckczt672hss2ra4/post/3lkz4lndbgc2o) |
| :---:   | :---: |
|![image](https://github.com/user-attachments/assets/9d0ddb0f-fe26-4336-b568-ea3d2c0ecf28) |![image](https://github.com/user-attachments/assets/8c22f819-02b8-46c4-a773-27219cb3a5a1)|