### PR TITLE
Sanitise content to prevent HTML being injected

### DIFF
--- a/src/bluesky.js
+++ b/src/bluesky.js
@@ -44,7 +44,7 @@ let insertAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("alt")));
+                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("alt").replaceAll("<","&lt;")));
             }
 
             // Add the element to the DOM
@@ -82,7 +82,7 @@ let insertAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("aria-label")));
+                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("aria-label").replaceAll("<","&lt;")));
             }
 
             // Add the element to the DOM

--- a/src/bluesky.js
+++ b/src/bluesky.js
@@ -38,13 +38,14 @@ let insertAlt = function () {
                 altText.style.backgroundColor = options.colorNoAlt;
                 altText.style.height = "12px";
             } else {
+                let sanitizedAltText = newlineToBr(userImage.getAttribute("alt").toHtmlEntities());
                 altText.style.color = options.colorAltText;
                 altText.style.backgroundColor = options.colorAltBg;
                 altText.style.fontSize = "18px";
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("alt").replaceAll("<","&lt;")));
+                altText.insertAdjacentHTML('beforeend', sanitizedAltText);
             }
 
             // Add the element to the DOM
@@ -76,13 +77,14 @@ let insertAlt = function () {
                 altText.style.backgroundColor = options.colorNoAlt;
                 altText.style.height = "12px";
             } else {
+                let sanitizedAltText = newlineToBr(userImage.getAttribute("aria-label").toHtmlEntities());
                 altText.style.color = options.colorAltText;
                 altText.style.backgroundColor = options.colorAltBg;
                 altText.style.fontSize = "18px";
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("aria-label").replaceAll("<","&lt;")));
+                altText.insertAdjacentHTML('beforeend', sanitizedAltText);
             }
 
             // Add the element to the DOM

--- a/src/common.js
+++ b/src/common.js
@@ -83,3 +83,13 @@ function getOptions() {
 function newlineToBr(text) {
     return text.replace(/\n/g, "<br>");
 }
+
+/**
+ * Convert a string to HTML entities
+ */
+String.prototype.toHtmlEntities = function() {
+    return this.replace(/./gm, function(s) {
+        // return "&#" + s.charCodeAt(0) + ";";
+        return (s.match(/[a-z0-9\s]+/i)) ? s : "&#" + s.charCodeAt(0) + ";";
+    });
+};

--- a/src/facebook.js
+++ b/src/facebook.js
@@ -45,7 +45,7 @@ let insertFBAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(fbImage.getAttribute("alt")));
+                altText.insertAdjacentHTML('beforeend', newlineToBr(fbImage.getAttribute("alt").replaceAll("<","&lt;")));
             } else {
                 altText.style.color = options.colorAltText;
                 altText.style.backgroundColor = options.colorAltBg;
@@ -53,7 +53,7 @@ let insertFBAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(fbImage.getAttribute("alt")));
+                altText.insertAdjacentHTML('beforeend', newlineToBr(fbImage.getAttribute("alt").replaceAll("<","&lt;")));
             }
 
             if (imageLink) {

--- a/src/facebook.js
+++ b/src/facebook.js
@@ -39,21 +39,23 @@ let insertFBAlt = function () {
                 fbImage.getAttribute("alt").includes("May be a") ||
                 fbImage.getAttribute("alt").includes("Photo by")
             ) {
+                let sanitizedAltText = newlineToBr(fbImage.getAttribute("alt").toHtmlEntities());
                 altText.style.color = options.colorAltText;
                 altText.style.backgroundColor = options.aiColorAltBg;
                 altText.style.fontSize = "18px";
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(fbImage.getAttribute("alt").replaceAll("<","&lt;")));
+                altText.insertAdjacentHTML('beforeend', sanitizedAltText);
             } else {
+                let sanitizedAltText = newlineToBr(fbImage.getAttribute("alt").toHtmlEntities());
                 altText.style.color = options.colorAltText;
                 altText.style.backgroundColor = options.colorAltBg;
                 altText.style.fontSize = "18px";
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(fbImage.getAttribute("alt").replaceAll("<","&lt;")));
+                altText.insertAdjacentHTML('beforeend', sanitizedAltText);
             }
 
             if (imageLink) {

--- a/src/instagram.js
+++ b/src/instagram.js
@@ -57,7 +57,7 @@ let insertIGAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.textContent = igImage.getAttribute("alt");
+                altText.textContent = igImage.getAttribute("alt").replaceAll("<","&lt;");
             } else {
                 altText.style.color = options.colorAltText;
                 altText.style.backgroundColor = options.colorAltBg;
@@ -65,7 +65,7 @@ let insertIGAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.textContent = igImage.getAttribute("alt");
+                altText.textContent = igImage.getAttribute("alt").replaceAll("<","&lt;");
             }
 
             if (imageLink) {

--- a/src/instagram.js
+++ b/src/instagram.js
@@ -57,7 +57,7 @@ let insertIGAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.textContent = igImage.getAttribute("alt").replaceAll("<","&lt;");
+                altText.textContent = igImage.getAttribute("alt").toHtmlEntities();
             } else {
                 altText.style.color = options.colorAltText;
                 altText.style.backgroundColor = options.colorAltBg;
@@ -65,7 +65,7 @@ let insertIGAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.textContent = igImage.getAttribute("alt").replaceAll("<","&lt;");
+                altText.textContent = igImage.getAttribute("alt").toHtmlEntities();
             }
 
             if (imageLink) {

--- a/src/linkedin.js
+++ b/src/linkedin.js
@@ -35,7 +35,7 @@ let insertLNAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(lnImage.getAttribute("alt")));
+                altText.insertAdjacentHTML('beforeend', newlineToBr(lnImage.getAttribute("alt").replaceAll("<","&lt;")));
             } else {
                 altText.style.color = options.colorAltText;
                 altText.style.backgroundColor = options.colorAltBg;
@@ -43,7 +43,7 @@ let insertLNAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(lnImage.getAttribute("alt")));
+                altText.insertAdjacentHTML('beforeend', newlineToBr(lnImage.getAttribute("alt").replaceAll("<","&lt;")));
             }
 
             if (imageLink) {

--- a/src/linkedin.js
+++ b/src/linkedin.js
@@ -29,21 +29,23 @@ let insertLNAlt = function () {
                 altText.style.backgroundColor = options.colorNoAlt;
                 altText.style.height = "12px";
             } else if (lnImage.getAttribute("alt").includes("Image preview")) {
+                let sanitizedAltText = newlineToBr(lnImage.getAttribute("alt").toHtmlEntities());
                 altText.style.color = options.colorAltText;
                 altText.style.backgroundColor = options.aiColorAltBg;
                 altText.style.fontSize = "18px";
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(lnImage.getAttribute("alt").replaceAll("<","&lt;")));
+                altText.insertAdjacentHTML('beforeend', sanitizedAltText);
             } else {
+                let sanitizedAltText = newlineToBr(lnImage.getAttribute("alt").toHtmlEntities());
                 altText.style.color = options.colorAltText;
                 altText.style.backgroundColor = options.colorAltBg;
                 altText.style.fontSize = "14px";
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(lnImage.getAttribute("alt").replaceAll("<","&lt;")));
+                altText.insertAdjacentHTML('beforeend', sanitizedAltText);
             }
 
             if (imageLink) {

--- a/src/mastodon.js
+++ b/src/mastodon.js
@@ -32,11 +32,11 @@ let insertMDAlt = function () {
                         altText.style.backgroundColor = options.colorNoAlt;
                         altText.style.height = "12px";
                     } else {
-                        alt = alt.replaceAll("<","&lt;"); /* avoid accidental markup alt being rendered */
+                        let sanitizedAltText = newlineToBr(alt.toHtmlEntities());
                         altText.style.color = options.colorAltText;
                         altText.style.backgroundColor = options.colorAltBg;
                         altText.style.padding = "0.75rem 1rem";
-                        altText.insertAdjacentHTML('beforeend', newlineToBr(alt));
+                        altText.insertAdjacentHTML('beforeend', sanitizedAltText);
                     }
 
                     visualAlt.appendChild(altText);

--- a/src/mastodon.js
+++ b/src/mastodon.js
@@ -32,6 +32,7 @@ let insertMDAlt = function () {
                         altText.style.backgroundColor = options.colorNoAlt;
                         altText.style.height = "12px";
                     } else {
+                        alt = alt.replaceAll("<","&lt;"); /* avoid accidental markup alt being rendered */
                         altText.style.color = options.colorAltText;
                         altText.style.backgroundColor = options.colorAltBg;
                         altText.style.padding = "0.75rem 1rem";

--- a/src/threads.js
+++ b/src/threads.js
@@ -38,21 +38,23 @@ let insertAlt = function () {
                 userImage.getAttribute("alt").includes("May be an image of") ||
                 userImage.getAttribute("alt").includes("Photo by")
             ) {
+                let sanitizedAltText = newlineToBr(userImage.getAttribute("alt").toHtmlEntities());
                 altText.style.color = options.colorAltText;
                 altText.style.backgroundColor = options.aiColorAltBg;
                 altText.style.fontSize = "18px";
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("alt").replaceAll("<","&lt;")));
+                altText.insertAdjacentHTML('beforeend', sanitizedAltText);
             } else {
+                let sanitizedAltText = newlineToBr(userImage.getAttribute("alt").toHtmlEntities());
                 altText.style.color = options.colorAltText;
                 altText.style.backgroundColor = options.colorAltBg;
                 altText.style.fontSize = "18px";
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("alt").replaceAll("<","&lt;")));
+                altText.insertAdjacentHTML('beforeend', sanitizedAltText);
             }
 
             // Add the element to the DOM

--- a/src/threads.js
+++ b/src/threads.js
@@ -44,7 +44,7 @@ let insertAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("alt")));
+                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("alt").replaceAll("<","&lt;")));
             } else {
                 altText.style.color = options.colorAltText;
                 altText.style.backgroundColor = options.colorAltBg;
@@ -52,7 +52,7 @@ let insertAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("alt")));
+                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("alt").replaceAll("<","&lt;")));
             }
 
             // Add the element to the DOM

--- a/src/tweetdeck.js
+++ b/src/tweetdeck.js
@@ -48,6 +48,7 @@ let insertTDAlt = function () {
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
                 let alt_text = tdImage.getAttribute("alt") || tdImage.getAttribute("title");
+                alt_text = alt_text.replaceAll("<","&lt;");
                 altText.insertAdjacentHTML('beforeend', newlineToBr(alt_text));
             }
 

--- a/src/tweetdeck.js
+++ b/src/tweetdeck.js
@@ -48,8 +48,8 @@ let insertTDAlt = function () {
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
                 let alt_text = tdImage.getAttribute("alt") || tdImage.getAttribute("title");
-                alt_text = alt_text.replaceAll("<","&lt;");
-                altText.insertAdjacentHTML('beforeend', newlineToBr(alt_text));
+                let sanitizedAltText = newlineToBr(alt_text.toHtmlEntities());
+                altText.insertAdjacentHTML('beforeend', sanitizedAltText);
             }
 
             if (imageLink) {

--- a/src/twitter.js
+++ b/src/twitter.js
@@ -55,7 +55,7 @@ let insertTWAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("alt")));
+                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("alt").replaceAll("<","&lt;")));
             }
 
             if (imageLink) {
@@ -92,7 +92,7 @@ let insertTWAlt = function () {
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(userGif.getAttribute("aria-label")));
+                altText.insertAdjacentHTML('beforeend', newlineToBr(userGif.getAttribute("aria-label").replaceAll("<","&lt;")));
             }
 
             if (gifLink) {

--- a/src/twitter.js
+++ b/src/twitter.js
@@ -49,13 +49,14 @@ let insertTWAlt = function () {
                 altText.style.backgroundColor = options.colorNoAlt;
                 altText.style.height = "12px";
             } else {
+                let sanitizedAltText = newlineToBr(userImage.getAttribute("alt").toHtmlEntities());
                 altText.style.color = options.colorAltText;
                 altText.style.backgroundColor = options.colorAltBg;
                 altText.style.fontSize = "18px";
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(userImage.getAttribute("alt").replaceAll("<","&lt;")));
+                altText.insertAdjacentHTML('beforeend', sanitizedAltText);
             }
 
             if (imageLink) {
@@ -86,13 +87,14 @@ let insertTWAlt = function () {
                 altText.style.backgroundColor = options.colorNoAlt;
                 altText.style.height = "12px";
             } else {
+                let sanitizedAltText = newlineToBr(userGif.getAttribute("aria-label").toHtmlEntities());
                 altText.style.color = options.colorAltText;
                 altText.style.backgroundColor = options.colorAltBg;
                 altText.style.fontSize = "18px";
                 altText.style.padding = "4px 8px";
                 altText.style.fontFamily =
                     'Arial, "Helvetica Neue", Helvetica, sans-serif';
-                altText.insertAdjacentHTML('beforeend', newlineToBr(userGif.getAttribute("aria-label").replaceAll("<","&lt;")));
+                altText.insertAdjacentHTML('beforeend', sanitizedAltText);
             }
 
             if (gifLink) {


### PR DESCRIPTION
Replaces `<` with escaped `&lt;` to prevent accidental (or malicious) rendering of actual HTML (as the code currently uses `insertAdjacentHTML` to allow for line breaks to be added).

EDIT: with thanks to @nickdenardis this now more thoroughly escapes any special HTML entities, just to be on the safe side.

Mastodon example before (using https://mastodon.social/@erikKroes/114589980635871953):

![screenshot showing the extension's alt display containing an actual html button element, as that's what was in the text alternative for the code sample screenshot](https://github.com/user-attachments/assets/f60d0c51-984f-40d4-944f-27fd5a4291ce)

Mastodon after:

![the same mastodon post, but now the alt display has the visible markup that was the text alternative for the image, readable rather than processed](https://github.com/user-attachments/assets/f43f46fe-2584-484f-9e0a-585e245c5792)

Bluesky example before (using https://bsky.app/profile/erikkroes.bsky.social/post/3lqc7m3zrg22l):

![same example the before in mastodon - a rendered actual button in the alt display](https://github.com/user-attachments/assets/df64e08a-169d-4e92-ae3a-de8a82f032ec)

Bluesky after:

![fixed ... the alt display shows the markup that was the text alternative for the image as text, not actually rendered as html](https://github.com/user-attachments/assets/45809722-1bf0-45e6-83cd-adb23c7515c3)